### PR TITLE
Tweaks no ticket

### DIFF
--- a/lib/JSON/Validator/Schema/OpenAPIv3.pm
+++ b/lib/JSON/Validator/Schema/OpenAPIv3.pm
@@ -142,7 +142,7 @@ sub _coerce_parameter_style_array {
     $re = qr{,} if $val->{value} =~ s/^$re// and !$explode;
   }
 
-  return $val->{value} = [_split($re, $val->{value})];
+  return $val->{value} = [split($re, $val->{value})];
 }
 
 sub _coerce_parameter_style_object {
@@ -157,7 +157,7 @@ sub _coerce_parameter_style_object {
     return if $style eq 'matrix' && $val->{value} !~ s/^;//;
     return if $style eq 'label'  && $val->{value} !~ s/^\.//;
     my $params = Mojo::Parameters->new;
-    $params->append(Mojo::Parameters->new($_)) for _split($re, $val->{value});
+    $params->append(Mojo::Parameters->new($_)) for split($re, $val->{value});
     return $val->{value} = $params->to_hash;
   }
   else {
@@ -172,7 +172,7 @@ sub _coerce_parameter_style_object {
     return unless my $re = $style_re->{$style};
     return if $style eq 'matrix' && $val->{value} !~ s/^;\Q$param->{name}\E=//;
     return if $style eq 'label'  && $val->{value} !~ s/^\.//;
-    return $val->{value} = Mojo::Parameters->new->pairs([_split($re, $val->{value})])->to_hash;
+    return $val->{value} = Mojo::Parameters->new->pairs([split($re, $val->{value})])->to_hash;
   }
 }
 
@@ -222,12 +222,6 @@ sub _get_parameter_value {
   my $val = $get->{$param->{in}}->($name, $param);
   @$val{qw(in name)} = (@$param{qw(in name)});
   return $val;
-}
-
-sub _split {
-  my ($re, $val) = @_;
-  $val = @$val ? $val->[-1] : '' if ref $val;
-  return split /$re/, $val;
 }
 
 sub _to_list { ref $_[0] eq 'ARRAY' ? @{$_[0]} : $_[0] ? ($_[0]) : () }

--- a/lib/JSON/Validator/Store.pm
+++ b/lib/JSON/Validator/Store.pm
@@ -141,7 +141,7 @@ sub _load_from_url {
 
   if ($cache_path and $cache_path ne BUNDLED_PATH and -w $cache_path) {
     $cache_file = path( $cache_path, $cache_file );
-    $cache_file->spurt($tx->res->body);
+    $cache_file->spew_utf8($tx->res->body);
   }
 
   return $self->add($url => $self->_parse($tx->res->body));

--- a/lib/JSON/Validator/Store.pm
+++ b/lib/JSON/Validator/Store.pm
@@ -3,7 +3,6 @@ package JSON::Validator::Store;
 use Digest::MD5 'md5_hex';
 use File::Spec;
 use JSON::MaybeXS ();
-use JSON::Validator::Schema;
 use JSON::Validator::Util qw(data_section);
 use Mojo::URL;
 use Mojo::UserAgent;


### PR DESCRIPTION
Running full test suite and found issues (`TEST_ONLINE=1 TEST_ACCEPTANCE=1 prove -lr t`)

- Path::Tiny uses spew (and friends) instead of spurt() to write files in JSON::Validator::Store
- Remove unused module causing a circular reference and redefined warnings in JSON::Validator::Store
- Removed the useless _split in OpenAPIv3 validator (unsure on this one) 